### PR TITLE
Finish Chessboard Calibration Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Add functionality to chessboard calibration
 | `src/camera_config/GH3_camera_config.yaml` | config file for FLIR grasshopper3 cameras |
 | `src/camera_config/ORYX_camera_config.yaml` | config file for FLIR ORYX cameras |
 | `src/opencv_objects/aruco_detector.py` | class for detecting ArUco markers |
+| `src/opencv_objects/chessboard_calibration.py` | class for calibrating stereo camera with chessboard |
 | `src/opencv_objects/epipolar_line_detector.py` | class for detecting epipolar lines |
 | `src/ui_objects/opencv_ui_controller.py` | main controller for UI |
 | `src/utils/file_utils.py` | utility functions for file operations |
@@ -98,6 +99,7 @@ Add functionality to chessboard calibration
 | `src/main_flir.py` | main function for starting application with FLIR cameras |
 | `src/main_realsense.py` | main function for starting application with realsense camera |
 | `tests/test_aruco_detector.py` | unit test for aruco detector |
+| `tests/test_chessboard_calibration.py` | unit test for chessboard calibration |
 | `tests/test_dual_realsense_system.py` | unit test for dual realsense camera system |
 | `tests/test_realsense_camera_system.py` | unit test for realsense camera system |
 | `tests/test_file_utils.py` | unit test for file utilities |
@@ -131,6 +133,7 @@ Add functionality to chessboard calibration
 │   ├── opencv_objects/
 │   │   ├── __init__.py
 │   │   ├── aruco_detector.py
+│   │   ├── chessboard_calibration.py
 │   │   └── epipolar_line_detector.py
 │   ├── ui_objects/
 │   │   ├── __init__.py
@@ -158,6 +161,7 @@ Add functionality to chessboard calibration
 │       └── aruco_depth_log.txt
 ├── tests/
 │   ├── test_aruco_detector.py
+│   ├── test_chessboard_calibration.py
 │   ├── test_dual_realsense_system.py
 │   ├── test_epipolar_line_detector.py
 │   ├── test_file_utils.py

--- a/README.md
+++ b/README.md
@@ -66,7 +66,14 @@
 
 ## Goal
 
-To be added
+Add functionality to chessboard calibration
+- press `c` or `C` to activate calibration mode
+    - Display detected chessboard immediately
+    - press `s` or `S` to add chessboard image to collection
+        - display image counter on window title
+        - save images in disk
+        - Optional: Add figure for reviewing reprojection error
+- press `c ` or `C` again to deactivate calibration mode
 
 ## File Structure
 

--- a/README.md
+++ b/README.md
@@ -42,18 +42,21 @@
 - [x] Read two Realsense IR camera streams and Realsense depth stream
 - [x] Detect ArUco markers for each stream
     - [x] Compute depths with detected ArUco markers and get depth from Realsense depth stream
-- [x] Display horizontal lines, vertical lines, and epipolar lines
-    - [x] Show epipolar lines from marker corners if ArUco markers are detected. If not, show epipolar lines from detected key points
-    - [x] Default algorithm for detecting key points is `ORB`, can be switched to `SIFT`
 - [x] Include interfaces for other cameras
     - [x] Interface for intel realsense cameras
     - [x] Interface for FLIR cameras
     - [x] Add support for multiple realsense cameras
+- [x] Display horizontal lines, vertical lines, and epipolar lines
+    - [x] Show epipolar lines from marker corners if ArUco markers are detected. If not, show epipolar lines from detected key points
+    - [x] Default algorithm for detecting key points is `ORB`, can be switched to `SIFT`
+- [ ] Chessboard calibration for stereo camera
+    - [ ] Show reprojection error per image
 - [x] Unit Tests
     - [x] ArUco detector
     - [x] Camera systems (not possible for FLIR cameras)
     - [x] Utility functions
-    - [ ] Epipolar line detector
+    - [x] Epipolar line detector
+    - [ ] Chessboard Calibration
 
 ### buttons for opencv_ui_controller.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,5 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pylint==3.2.7",
-    "pytest==7.4.4"
+    "coverage==7.6.1"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,10 @@
 addopts = ["--import-mode=importlib"]
 pythonpath = "./src"
 [tool.coverage.run]
+omit = [
+    "config.py",
+    "config-3.py",
+    ]
 branch = true
 
 [tool.coverage.report]

--- a/src/main_flir.py
+++ b/src/main_flir.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
 
     UI = OpencvUIController(system_prefix="GH3", focal_length=FOCAL_LENGTH, baseline=BASELINE)
 
-    CONFIG = "./camera_config/GH3_camera_config.yaml"
+    CONFIG = "./src/camera_config/GH3_camera_config.yaml"
     SN1 = "21091478"
     SN2 = "21091470"
 

--- a/src/opencv_objects/__init__.py
+++ b/src/opencv_objects/__init__.py
@@ -1,15 +1,17 @@
 """
 This module initializes the OpenCV objects package.
-It imports the ArUcoDetector and EpipolarLineDetector classes from their respective modules and
-sets the __all__ variable to include both classes.
+It imports the ArUcoDetector, EpipolarLineDetector, and ChessboardCalibrator classes from their respective modules and
+sets the __all__ variable to include all three classes.
 Classes:
     ArUcoDetector: A class for detecting ArUco markers.
     EpipolarLineDetector: A class for detecting epipolar lines.
+    ChessboardCalibrator: A class for calibrating stereo cameras.
 __all__:
     List of public objects of that module, as interpreted by import *.
 """
 
 from .aruco_detector import ArUcoDetector
 from .epipolar_line_detector import EpipolarLineDetector
+from .chessboard_calibration import ChessboardCalibrator
 
-__all__ = ["ArUcoDetector", "EpipolarLineDetector"]
+__all__ = ["ArUcoDetector", "EpipolarLineDetector", "ChessboardCalibrator"]

--- a/src/opencv_objects/__init__.py
+++ b/src/opencv_objects/__init__.py
@@ -1,7 +1,7 @@
 """
-This module initializes the ArUco detector package.
-It imports the ArUcoDetector class from the aruco_detector module and
-sets the __all__ variable to include only the ArUcoDetector class.
+This module initializes the OpenCV objects package.
+It imports the ArUcoDetector and EpipolarLineDetector classes from their respective modules and
+sets the __all__ variable to include both classes.
 Classes:
     ArUcoDetector: A class for detecting ArUco markers.
     EpipolarLineDetector: A class for detecting epipolar lines.

--- a/src/opencv_objects/chessboard_calibration.py
+++ b/src/opencv_objects/chessboard_calibration.py
@@ -343,9 +343,9 @@ class ChessboardCalibrator():
         Args:
             db_path (str): Directory path to save the JSON files.
         """
-        left_parameter_save_path = db_path + "left_camera_parameters.json"
-        right_parameter_save_path = db_path + "right_camera_parameters.json"
-        stereo_parameter_save_path = db_path + "stereo_camera_parameters.json"
+        left_parameter_save_path = db_path + "/left_camera_parameters.json"
+        right_parameter_save_path = db_path + "/right_camera_parameters.json"
+        stereo_parameter_save_path = db_path + "/stereo_camera_parameters.json"
 
         def serialize_numpy(obj: Any) -> Any:
             if isinstance(obj, np.ndarray):

--- a/src/opencv_objects/chessboard_calibration.py
+++ b/src/opencv_objects/chessboard_calibration.py
@@ -1,0 +1,360 @@
+"""
+Module for calibrating cameras using a chessboard pattern.
+"""
+
+import logging
+from typing import Tuple, List, Dict, Any
+
+import json
+
+import cv2
+import numpy as np
+
+class ChessboardCalibrator():
+    """
+    Class for calibrating single and stereo cameras using a chessboard pattern.
+    """
+    def __init__(self,
+                 pattern_size: Tuple[int, int] = (11, 7),
+                 square_size_mm: float = 30.0
+                 ) -> None:
+        self._pattern_size = pattern_size
+        self._square_size_mm = square_size_mm
+
+        self._left_calibration_parameters: Dict[str, Any] = {}
+        self._right_calibration_parameters: Dict[str, Any] = {}
+        self._stereo_calibration_parameters: Dict[str, Any] = {}
+
+        logging.info("ChessboardCalibrator initialized with pattern size %s and square size mm %s.",
+                        pattern_size, square_size_mm)
+
+    @property
+    def pattern_size(self) -> Tuple[int, int]:
+        """
+        Get the pattern size of the chessboard.
+
+        Returns:
+            Tuple[int, int]: Pattern size of the chessboard.
+        """
+        return self._pattern_size
+
+    @pattern_size.setter
+    def pattern_size(self, new_pattern_size: Tuple[int, int]) -> None:
+        """
+        Set a new pattern size for the chessboard.
+
+        Args:
+            new_pattern_size (Tuple[int, int]): New pattern size of the chessboard.
+        """
+        self._pattern_size = new_pattern_size
+        logging.info("Pattern size set to %s.", new_pattern_size)
+
+    @property
+    def square_size_mm(self) -> float:
+        """
+        Get the square size of the chessboard in millimeters.
+
+        Returns:
+            float: Square size of the chessboard in millimeters.
+        """
+        return self._square_size_mm
+
+    @square_size_mm.setter
+    def square_size_mm(self, new_square_size_mm: float) -> None:
+        """
+        Set a new square size for the chessboard in millimeters.
+
+        Args:
+            new_square_size_mm (float): New square size of the chessboard in millimeters.
+        """
+        self._square_size_mm = new_square_size_mm
+        logging.info("Square size mm set to %f.", new_square_size_mm)
+
+    @property
+    def left_camera_parameters(self) -> Dict[str, Any]:
+        """
+        Get the calibration parameters for the left camera.
+
+        Returns:
+            Dict[str, Any]: Calibration parameters for the left camera.
+        """
+        return self._left_calibration_parameters
+
+    @left_camera_parameters.setter
+    def left_camera_parameters(self, parameters: Dict[str, Any]) -> None:
+        """
+        Set the calibration parameters for the left camera.
+
+        Args:
+            parameters (Dict[str, Any]): Calibration parameters for the left camera.
+        """
+        self._left_calibration_parameters = parameters
+        logging.info("Left camera parameters set.")
+
+    @property
+    def right_camera_parameters(self) -> Dict[str, Any]:
+        """
+        Get the calibration parameters for the right camera.
+
+        Returns:
+            Dict[str, Any]: Calibration parameters for the right camera.
+        """
+        return self._right_calibration_parameters
+
+    @right_camera_parameters.setter
+    def right_camera_parameters(self, parameters: Dict[str, Any]) -> None:
+        """
+        Set the calibration parameters for the right camera.
+
+        Args:
+            parameters (Dict[str, Any]): Calibration parameters for the right camera.
+        """
+        self._right_calibration_parameters = parameters
+        logging.info("Right camera parameters set.")
+
+    @property
+    def stereo_camera_parameters(self) -> Dict[str, Any]:
+        """
+        Get the calibration parameters for the stereo camera setup.
+
+        Returns:
+            Dict[str, Any]: Calibration parameters for the stereo camera setup.
+        """
+        return self._stereo_calibration_parameters
+
+    @stereo_camera_parameters.setter
+    def stereo_camera_parameters(self, parameters: Dict[str, Any]) -> None:
+        """
+        Set the calibration parameters for the stereo camera setup.
+
+        Args:
+            parameters (Dict[str, Any]): Calibration parameters for the stereo camera setup.
+        """
+        self._stereo_calibration_parameters = parameters
+        logging.info("Stereo camera parameters set.")
+
+    def detect_chessboard_corners(self, image: np.ndarray) -> Tuple[bool, np.ndarray]:
+        """
+        Detect chessboard corners in a single image, and return detected corners and IDs.
+
+        Args:
+            image (np.ndarray): Image, should include chessboard pattern.
+
+        Returns:
+            Tuple[bool, np.ndarray]:
+                - bool: Whether corners were detected.
+                - np.ndarray: Detected corners in image.
+        """
+        ret, corners = cv2.findChessboardCorners(image, self.pattern_size)
+        if ret:
+            criteria = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 30, 0.001)
+            corners = cv2.cornerSubPix(image, corners, (5, 5), (-1, -1), criteria)
+            return ret, corners
+        return ret, None
+
+    def display_chessboard_corners(self, image: np.ndarray, corners: np.ndarray) -> np.ndarray:
+        """
+        Display chessboard corners on an image.
+
+        Args:
+            image (np.ndarray): Image, should include chessboard pattern.
+            corners (np.ndarray): Detected corners in image.
+
+        Returns:
+            np.ndarray: Image with corners drawn.
+        """
+        return cv2.drawChessboardCorners(image, self.pattern_size, corners, True)
+
+    def calibrate_single_camera(self,
+                         image_points: List[np.ndarray],
+                         image_size: Tuple[int, int],
+                         camera_index: int = 0
+                         ) -> bool:
+        """
+        Calibrate a single camera using detected image points.
+
+        Args:
+            image_points (List[np.ndarray]): List of detected image points.
+            image_size (Tuple[int, int]): Size of the image.
+            camera_index (int): Index of the camera. `0` for left camera, `1` for right camera.
+
+        Returns:
+            bool: Whether calibration was successful.
+        """
+        assert len(image_points) > 0, "No image points detected."
+        obj_points = self._generate_object_points(len(image_points))
+        ret, mtx, dist, rvecs, tvecs = cv2.calibrateCamera(obj_points, image_points, image_size,
+                                                           cameraMatrix=None, distCoeffs=None)
+
+        # arbitrary threshold for successful calibration
+        if ret > 3.0:
+            logging.error("Camera calibration failed.")
+            return False
+
+        if camera_index == 0:
+            self._left_calibration_parameters = {
+                "image_points": image_points,
+                "object_points": obj_points,
+                "camera_matrix": mtx,
+                "distortion_coefficients": dist,
+                "rotation_vectors": rvecs,
+                "translation_vectors": tvecs
+            }
+        elif camera_index == 1:
+            self._right_calibration_parameters = {
+                "image_points": image_points,
+                "object_points": obj_points,
+                "camera_matrix": mtx,
+                "distortion_coefficients": dist,
+                "rotation_vectors": rvecs,
+                "translation_vectors": tvecs
+            }
+
+        return True
+
+    def calibrate_stereo_camera(self,
+                                left_image_points: List[np.ndarray],
+                                right_image_points: List[np.ndarray],
+                                image_size: Tuple[int, int]
+                                ) -> bool:
+        """
+        Calibrate a stereo camera setup using detected image points from both cameras.
+
+        Args:
+            left_image_points (List[np.ndarray]): List of detected image points from the left camera.
+            right_image_points (List[np.ndarray]): List of detected image points from the right camera.
+            image_size (Tuple[int, int]): Size of the image.
+
+        Returns:
+            bool: Whether calibration was successful.
+        """
+        assert len(left_image_points) == len(right_image_points), \
+             "Number of points in left and right images must be equal."
+
+        single_calibration_success = True
+        single_calibration_success &= self.calibrate_single_camera(left_image_points, image_size, camera_index=0)
+        single_calibration_success &= self.calibrate_single_camera(right_image_points, image_size, camera_index=1)
+        if not single_calibration_success:
+            logging.error("Stereo camera calibration failed.")
+            return False
+
+        mtx_left = self._left_calibration_parameters["camera_matrix"]
+        dist_left = self._left_calibration_parameters["distortion_coefficients"]
+        mtx_right = self._right_calibration_parameters["camera_matrix"]
+        dist_right = self._right_calibration_parameters["distortion_coefficients"]
+
+        obj_points = self._generate_object_points(len(left_image_points))
+        ret, new_mtx_left, new_dist_left, new_mtx_right, new_dist_right, \
+            rotation, translation, essential, fundamental = cv2.stereoCalibrate(
+            obj_points, left_image_points, right_image_points,
+            mtx_left, dist_left, mtx_right, dist_right,
+            image_size, flags=None, criteria=None
+            )
+
+        # arbitrary threshold for successful calibration
+        if ret > 3.0:
+            logging.error("Stereo camera calibration failed.")
+            return False
+
+        left_rectified_rotation, right_rectified_rotation, \
+              left_projection, right_projection, \
+                reprojection, \
+                    left_roi, right_roi = \
+                        cv2.stereoRectify(new_mtx_left, new_dist_left, new_mtx_right, new_dist_right, \
+                                          image_size, rotation, translation)
+
+        self._stereo_calibration_parameters = {
+            "image_points_left": left_image_points,
+            "image_points_right": right_image_points,
+            "object_points": obj_points,
+            "camera_matrix_left": new_mtx_left,
+            "distortion_coefficients_left": new_dist_left,
+            "camera_matrix_right": new_mtx_right,
+            "distortion_coefficients_right": new_dist_right,
+            "rotation_matrix": rotation,
+            "translation_vector": translation,
+            "essential_matrix": essential,
+            "fundamental_matrix": fundamental,
+            "left_rectified_rotation_matrix": left_rectified_rotation,
+            "right_rectified_rotation_matrix": right_rectified_rotation,
+            "left_projection_matrix": left_projection,
+            "right_projection_matrix": right_projection,
+            "reprojection_matrix": reprojection,
+            "left_rectified_roi": left_roi,
+            "right_rectified_roi": right_roi
+        }
+
+        return True
+
+    def rectify_images(self, left_image: np.ndarray, right_image: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Rectify a pair of stereo images using the calibration parameters.
+
+        Args:
+            left_image (np.ndarray): Image from the left camera.
+            right_image (np.ndarray): Image from the right camera.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: Rectified images from the left and right cameras.
+        """
+        left_map1, left_map2 = cv2.initUndistortRectifyMap(
+            self._stereo_calibration_parameters["camera_matrix_left"],
+            self._stereo_calibration_parameters["distortion_coefficients_left"],
+            self._stereo_calibration_parameters["left_rectified_rotation_matrix"],
+            self._stereo_calibration_parameters["left_projection_matrix"],
+            left_image.shape[:2][::-1],
+            cv2.CV_16SC2
+        )
+
+        right_map1, right_map2 = cv2.initUndistortRectifyMap(
+            self._stereo_calibration_parameters["camera_matrix_right"],
+            self._stereo_calibration_parameters["distortion_coefficients_right"],
+            self._stereo_calibration_parameters["right_rectified_rotation_matrix"],
+            self._stereo_calibration_parameters["right_projection_matrix"],
+            right_image.shape[:2][::-1],
+            cv2.CV_16SC2
+        )
+
+        left_rectified = cv2.remap(left_image, left_map1, left_map2, cv2.INTER_LINEAR)
+        right_rectified = cv2.remap(right_image, right_map1, right_map2, cv2.INTER_LINEAR)
+
+        return left_rectified, right_rectified
+
+    def save_parameters(self, db_path: str = "./") -> None:
+        """
+        Save the calibration parameters to JSON files.
+
+        Args:
+            db_path (str): Directory path to save the JSON files.
+        """
+        left_parameter_save_path = db_path + "left_camera_parameters.json"
+        right_parameter_save_path = db_path + "right_camera_parameters.json"
+        stereo_parameter_save_path = db_path + "stereo_camera_parameters.json"
+
+        def serialize_numpy(obj: Any) -> Any:
+            if isinstance(obj, np.ndarray):
+                return obj.tolist()
+            raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+        with open(left_parameter_save_path, "w", encoding="UTF-8") as left_file:
+            json.dump(self._left_calibration_parameters, left_file, default=serialize_numpy)
+
+        with open(right_parameter_save_path, "w", encoding="UTF-8") as right_file:
+            json.dump(self._right_calibration_parameters, right_file, default=serialize_numpy)
+
+        with open(stereo_parameter_save_path, "w", encoding="UTF-8") as stereo_file:
+            json.dump(self._stereo_calibration_parameters, stereo_file, default=serialize_numpy)
+
+    def _generate_object_points(self, num_images: int) -> List[np.ndarray]:
+        """
+        Generate object points for the chessboard pattern.
+
+        Args:
+            num_images (int): Number of images.
+
+        Returns:
+            List[np.ndarray]: List of object points.
+        """
+        objp = np.zeros((self.pattern_size[0] * self.pattern_size[1], 3), np.float32)
+        objp[:, :2] = np.mgrid[0:self.pattern_size[0], 0:self.pattern_size[1]].T.reshape(-1, 2)
+        return [objp for _ in range(num_images)]

--- a/src/ui_objects/opencv_ui_controller.py
+++ b/src/ui_objects/opencv_ui_controller.py
@@ -448,19 +448,6 @@ class OpencvUIController():
             self.image_points['left'].append(corners_left)
             self.image_points['right'].append(corners_right)
 
-            left_chessboard_dir = os.path.join(self.base_dir, "left_chessboard_images")
-            right_chessboard_dir = os.path.join(self.base_dir, "right_chessboard_images")
-
-            left_chessboard_path = os.path.join(left_chessboard_dir,
-                                                f"left_chessboard{self.chessboard_image_index}.png")
-            right_chessboard_path = os.path.join(right_chessboard_dir,
-                                                 f"right_chessboard{self.chessboard_image_index}.png")
-
-            cv2.imwrite(left_chessboard_path, left_gray_image)
-            cv2.imwrite(right_chessboard_path, right_gray_image)
-
-            logging.info("Saved chessboard images - Left: %s, Right: %s", left_chessboard_path, right_chessboard_path)
-
             save_images(self.base_dir, left_gray_image, right_gray_image,
                         self.chessboard_image_index, prefix="chessboard")
 

--- a/src/ui_objects/opencv_ui_controller.py
+++ b/src/ui_objects/opencv_ui_controller.py
@@ -69,6 +69,8 @@ class OpencvUIController():
         self.epipolar_detector = EpipolarLineDetector()
         self.draw_epipolar_lines = False
 
+        self.calibration_mode = False
+
     def set_camera_system(self, camera_system: TwoCamerasSystem) -> None:
         """
         Set the camera system for the application.
@@ -83,14 +85,23 @@ class OpencvUIController():
 
     def start(self) -> None:
         """
-        Start the application.
-        - Press `s` or `S` to save images.
-        - Press `esc` to exit.
-
-        args:
+        This method initializes the OpenCV window and enters a loop to continuously
+        capture and process images from the camera system. It handles various key
+        presses to perform actions such as saving images, toggling display options,
+        and terminating the application.
+        Key Presses:
+        - `s` or `S`: Save images. (only if not in calibration mode)
+        - `esc`: Exit the application.
+        - `h` or `H`: Toggle horizontal lines.
+        - `v` or `V`: Toggle vertical lines.
+        - `e` or `E`: Toggle epipolar lines.
+            - `n`: Switch to the next epipolar detector (only if epipolar lines are enabled).
+            - `p`: Switch to the previous epipolar detector (only if epipolar lines are enabled).
+        - `c` or `C`: Toggle calibration mode.
+            - `s` or `S`: Save chessboard images. (only if in calibration mode)
+        Args:
         No arguments.
-
-        returns:
+        Returns:
         No return.
         """
         cv2.namedWindow("Combined View (2x2)")
@@ -115,7 +126,9 @@ class OpencvUIController():
                 cv2.destroyAllWindows()
                 break
             if key == ord('s') or key == ord('S'):  # Save images
-                self._save_images(left_gray_image, right_gray_image, first_depth_image, second_depth_image)
+                if not self.calibration_mode:
+                    self._save_images(left_gray_image, right_gray_image, first_depth_image, second_depth_image)
+
             if key == ord('h') or key == ord('H'):  # Toggle horizontal lines
                 self.draw_horizontal_lines = not self.draw_horizontal_lines
             if key == ord('v') or key == ord('V'):  # Toggle vertical lines
@@ -130,6 +143,8 @@ class OpencvUIController():
                 if key == ord('p'):  # Switch to previous detector
                     self.epipolar_detector.switch_detector('p')
                     self._update_window_title()
+            if key == ord('c') or key == ord('C'):
+                self.calibration_mode = not self.calibration_mode
 
     def _update_window_title(self) -> None:
         """

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -3,12 +3,16 @@ This module initializes utility functions for the Depth Estimator ArUco project.
 Imports:
     get_starting_index (from .file_utils): Function to get the starting index.
     parse_yaml_config (from .file_utils): Function to parse YAML configuration files.
+    setup_directories (from .file_utils): Function to set up directories for storing images and logs.
+    setup_logging (from .file_utils): Function to set up logging configuration.
 __all__:
     List of public objects of that module, as interpreted by import *.
     - 'get_starting_index'
     - 'parse_yaml_config'
+    - 'setup_directories'
+    - 'setup_logging'
 """
 
-from .file_utils import get_starting_index, parse_yaml_config
+from .file_utils import get_starting_index, parse_yaml_config, setup_directories, setup_logging, save_images
 
-__all__ = ['get_starting_index', 'parse_yaml_config']
+__all__ = ['get_starting_index', 'parse_yaml_config', 'setup_directories', 'setup_logging', 'save_images']

--- a/tests/test_aruco_detector.py
+++ b/tests/test_aruco_detector.py
@@ -3,10 +3,12 @@ Unit tests for the ArUcoDetector class.
 """
 
 import unittest
+import coverage
+
 import numpy as np
 import cv2
+
 from src.opencv_objects import ArUcoDetector
-import coverage
 
 class TestArUcoDetector(unittest.TestCase):
     """

--- a/tests/test_aruco_detector.py
+++ b/tests/test_aruco_detector.py
@@ -6,6 +6,7 @@ import unittest
 import numpy as np
 import cv2
 from src.opencv_objects import ArUcoDetector
+import coverage
 
 class TestArUcoDetector(unittest.TestCase):
     """
@@ -64,4 +65,13 @@ class TestArUcoDetector(unittest.TestCase):
         self.assertEqual(len(matching_ids), 0)
 
 if __name__ == '__main__':
+    cov = coverage.Coverage()
+    cov.start()
+
     unittest.main()
+
+    cov.stop()
+    cov.save()
+
+    cov.html_report()
+    print("Done.")

--- a/tests/test_chessboard_calibration.py
+++ b/tests/test_chessboard_calibration.py
@@ -82,7 +82,7 @@ class TestChessboardCalibrator(unittest.TestCase):
         """
         pattern_size = (7, 7)
         self.calibrator.pattern_size = pattern_size
-        image_points = self._generate_image_points(pattern_size, 20)
+        image_points = self._generate_image_points(pattern_size, 3)
         image_size = (640, 480)
         ret = self.calibrator.calibrate_single_camera(image_points, image_size, camera_index=0)
         self.assertTrue(ret)
@@ -103,8 +103,8 @@ class TestChessboardCalibrator(unittest.TestCase):
         """
         pattern_size = (7, 7)
         self.calibrator.pattern_size = pattern_size
-        left_image_points = self._generate_image_points(pattern_size, 20)
-        right_image_points = self._generate_image_points(pattern_size, 20)
+        left_image_points = self._generate_image_points(pattern_size, 3)
+        right_image_points = self._generate_image_points(pattern_size, 3)
         image_size = (640, 480)
         ret = self.calibrator.calibrate_stereo_camera(left_image_points, right_image_points, image_size)
         self.assertTrue(ret)

--- a/tests/test_chessboard_calibration.py
+++ b/tests/test_chessboard_calibration.py
@@ -4,8 +4,11 @@ Unit tests for the ChessboardCalibrator class.
 
 from typing import List, Tuple
 import unittest
+import coverage
+
 import numpy as np
 import cv2
+
 from src.opencv_objects import ChessboardCalibrator
 
 class TestChessboardCalibrator(unittest.TestCase):
@@ -182,4 +185,13 @@ class TestChessboardCalibrator(unittest.TestCase):
         return image_points
 
 if __name__ == '__main__':
+    cov = coverage.Coverage()
+    cov.start()
+
     unittest.main()
+
+    cov.stop()
+    cov.save()
+
+    cov.html_report()
+    print("Done.")

--- a/tests/test_chessboard_calibration.py
+++ b/tests/test_chessboard_calibration.py
@@ -1,0 +1,185 @@
+"""
+Unit tests for the ChessboardCalibrator class.
+"""
+
+from typing import List, Tuple
+import unittest
+import numpy as np
+import cv2
+from src.opencv_objects import ChessboardCalibrator
+
+class TestChessboardCalibrator(unittest.TestCase):
+    """
+    Test cases for the ChessboardCalibrator class.
+    """
+
+    def setUp(self):
+        """
+        Set up the test case environment.
+        """
+        self.calibrator = ChessboardCalibrator()
+
+    def test_initialization(self):
+        """
+        Test the initialization of the ChessboardCalibrator.
+        """
+        self.assertEqual(self.calibrator.pattern_size, (11, 7))
+        self.assertEqual(self.calibrator.square_size_mm, 30.0)
+
+    def test_set_pattern_size(self):
+        """
+        Test setting a new pattern size for the chessboard.
+        """
+        new_pattern_size = (9, 6)
+        self.calibrator.pattern_size = new_pattern_size
+        self.assertEqual(self.calibrator.pattern_size, new_pattern_size)
+
+    def test_set_square_size_mm(self):
+        """
+        Test setting a new square size for the chessboard in millimeters.
+        """
+        new_square_size_mm = 25.0
+        self.calibrator.square_size_mm = new_square_size_mm
+        self.assertEqual(self.calibrator.square_size_mm, new_square_size_mm)
+
+    def test_detect_chessboard_corners_success(self):
+        """
+        Test successful detection of chessboard corners in an image.
+        """
+        # Create a synthetic chessboard image with white squares on a black background
+        pattern_size = (8, 8)
+        square_size = 50
+        chessboard_image = np.zeros((pattern_size[0] * square_size, pattern_size[1] * square_size), dtype=np.uint8)
+
+        for i in range(pattern_size[0]):
+            for j in range(pattern_size[1]):
+                if (i + j) % 2 == 0:
+                    cv2.rectangle(chessboard_image,
+                        (j * square_size, i * square_size),
+                        ((j + 1) * square_size, (i + 1) * square_size),
+                        (255, 255, 255),
+                        -1)
+
+        self.calibrator.pattern_size = (pattern_size[0] - 1, pattern_size[1] - 1)
+        ret, corners = self.calibrator.detect_chessboard_corners(chessboard_image)
+        self.assertTrue(ret)
+        self.assertIsNotNone(corners)
+
+    def test_detect_chessboard_corners_failure(self):
+        """
+        Test failure to detect chessboard corners in an image without a chessboard.
+        """
+        # Create an image without a chessboard
+        image = np.zeros((500, 500), dtype=np.uint8)
+
+        ret, corners = self.calibrator.detect_chessboard_corners(image)
+        self.assertFalse(ret)
+        self.assertIsNone(corners)
+
+    def test_calibrate_single_camera_success(self):
+        """
+        Test successful calibration of a single camera.
+        """
+        pattern_size = (7, 7)
+        self.calibrator.pattern_size = pattern_size
+        image_points = self._generate_image_points(pattern_size, 20)
+        image_size = (640, 480)
+        ret = self.calibrator.calibrate_single_camera(image_points, image_size, camera_index=0)
+        self.assertTrue(ret)
+        self.assertIn("camera_matrix", self.calibrator.left_camera_parameters)
+
+    def test_calibrate_single_camera_failure(self):
+        """
+        Test failure to calibrate a single camera with no image points.
+        """
+        image_points = []  # No image points
+        image_size = (640, 480)
+        with self.assertRaises(AssertionError):
+            self.calibrator.calibrate_single_camera(image_points, image_size, camera_index=0)
+
+    def test_calibrate_stereo_camera_success(self):
+        """
+        Test successful calibration of a stereo camera setup.
+        """
+        pattern_size = (7, 7)
+        self.calibrator.pattern_size = pattern_size
+        left_image_points = self._generate_image_points(pattern_size, 20)
+        right_image_points = self._generate_image_points(pattern_size, 20)
+        image_size = (640, 480)
+        ret = self.calibrator.calibrate_stereo_camera(left_image_points, right_image_points, image_size)
+        self.assertTrue(ret)
+        self.assertIn("camera_matrix_left", self.calibrator.stereo_camera_parameters)
+        self.assertIn("camera_matrix_right", self.calibrator.stereo_camera_parameters)
+
+    def test_calibrate_stereo_camera_failure(self):
+        """
+        Test failure to calibrate a stereo camera setup with mismatched number of points.
+        """
+        left_image_points = [np.random.rand(49, 1, 2).astype(np.float32) for _ in range(10)]
+        right_image_points = []  # Mismatched number of points
+        image_size = (640, 480)
+        with self.assertRaises(AssertionError):
+            self.calibrator.calibrate_stereo_camera(left_image_points, right_image_points, image_size)
+
+    def test_rectify_images_success(self):
+        """
+        Test successful rectification of stereo images.
+        """
+        left_image = np.random.rand(480, 640, 3).astype(np.uint8)
+        right_image = np.random.rand(480, 640, 3).astype(np.uint8)
+        self.calibrator.stereo_camera_parameters = {
+            "camera_matrix_left": np.eye(3),
+            "distortion_coefficients_left": np.zeros(5),
+            "camera_matrix_right": np.eye(3),
+            "distortion_coefficients_right": np.zeros(5),
+            "left_rectified_rotation_matrix": np.eye(3),
+            "right_rectified_rotation_matrix": np.eye(3),
+            "left_projection_matrix": np.eye(3),
+            "right_projection_matrix": np.eye(3)
+        }
+        left_rectified, right_rectified = self.calibrator.rectify_images(left_image, right_image)
+        self.assertEqual(left_rectified.shape, left_image.shape)
+        self.assertEqual(right_rectified.shape, right_image.shape)
+
+    def test_rectify_images_failure(self):
+        """
+        Test failure to rectify stereo images with missing calibration parameters.
+        """
+        left_image = np.random.rand(480, 640, 3).astype(np.uint8)
+        right_image = np.random.rand(480, 640, 3).astype(np.uint8)
+        with self.assertRaises(KeyError):
+            self.calibrator.rectify_images(left_image, right_image)
+
+    def _generate_image_points(self, pattern_size: Tuple[int, int], num_images: int) -> List[np.ndarray]:
+        """
+        Helper method to generate synthetic image points for testing.
+
+        Args:
+            pattern_size (Tuple[int, int]): Size of the chessboard pattern.
+            num_images (int): Number of images.
+
+        Returns:
+            List[np.ndarray]: List of synthetic image points.
+        """
+        total_squares = pattern_size[0] * pattern_size[1]
+        object_points = np.zeros((total_squares, 2), np.float32)
+        object_points[:, :2] = np.mgrid[0:pattern_size[0], 0:pattern_size[1]].T.reshape(-1, 2)
+
+        image_points = []
+        for _ in range(num_images):
+            # Apply random rotation and scaling
+            angle = np.random.uniform(-30, 30)
+            scale = np.random.uniform(0.8, 1.2)
+            rotation_matrix = cv2.getRotationMatrix2D((pattern_size[0] / 2, pattern_size[1] / 2), angle, scale)
+            transformed_points = cv2.transform(np.array([object_points[:, :2]]), rotation_matrix)[0]
+
+            # Add some noise
+            noise = np.random.normal(0, 0.5, transformed_points.shape)
+            transformed_points += noise
+
+            image_points.append(transformed_points.astype(np.float32).reshape(-1, 1, 2))
+
+        return image_points
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_dual_realsense_system.py
+++ b/tests/test_dual_realsense_system.py
@@ -3,12 +3,12 @@ Unit tests for the DualRealsenseSystem class.
 """
 import logging
 import unittest
+import coverage
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 
-from src.camera_objects import DualRealsenseSystem
-from src.camera_objects import RealsenseCameraSystem
+from src.camera_objects import RealsenseCameraSystem, DualRealsenseSystem
 
 class TestDualRealsenseSystem(unittest.TestCase):
     """
@@ -117,4 +117,13 @@ class TestDualRealsenseSystem(unittest.TestCase):
         self.mock_camera2.release.assert_called_once()
 
 if __name__ == '__main__':
+    cov = coverage.Coverage()
+    cov.start()
+
     unittest.main()
+
+    cov.stop()
+    cov.save()
+
+    cov.html_report()
+    print("Done.")

--- a/tests/test_dual_realsense_system.py
+++ b/tests/test_dual_realsense_system.py
@@ -2,9 +2,10 @@
 Unit tests for the DualRealsenseSystem class.
 """
 import logging
+
+from unittest.mock import MagicMock, patch
 import unittest
 import coverage
-from unittest.mock import MagicMock, patch
 
 import numpy as np
 

--- a/tests/test_epipolar_line_detector.py
+++ b/tests/test_epipolar_line_detector.py
@@ -10,7 +10,9 @@ Classes
 TestEpipolarLineDetector:
 
 """
+import logging
 import unittest
+
 import cv2
 import numpy as np
 
@@ -63,6 +65,14 @@ class TestEpipolarLineDetector(unittest.TestCase):
         cv2.line(self.right_image, (410, 410), (510, 510), (0, 0, 255), 5)  # Red line
         self.corners_left = np.array([[[100, 100], [200, 100], [200, 200], [100, 200]]], dtype=np.float32)
         self.corners_right = np.array([[[110, 110], [210, 110], [210, 210], [110, 210]]], dtype=np.float32)
+
+        logging.disable(logging.CRITICAL)  # Suppress log messages below CRITICAL level
+
+    def tearDown(self):
+        """
+        Clean up the test environment after each test.
+        """
+        logging.disable(logging.NOTSET)  # Re-enable logging after tests
 
     def test_set_feature_detector(self):
         """

--- a/tests/test_epipolar_line_detector.py
+++ b/tests/test_epipolar_line_detector.py
@@ -12,6 +12,7 @@ TestEpipolarLineDetector:
 """
 import logging
 import unittest
+import coverage
 
 import cv2
 import numpy as np
@@ -121,4 +122,13 @@ class TestEpipolarLineDetector(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    cov = coverage.Coverage()
+    cov.start()
+
     unittest.main()
+
+    cov.stop()
+    cov.save()
+
+    cov.html_report()
+    print("Done.")

--- a/tests/test_epipolar_line_detector.py
+++ b/tests/test_epipolar_line_detector.py
@@ -11,6 +11,7 @@ TestEpipolarLineDetector:
 
 """
 import logging
+
 import unittest
 import coverage
 

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -2,13 +2,16 @@
 Unit tests for the file_utils module.
 """
 
+import os
 import logging
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, call
 
 import yaml
+import numpy as np
 
-from src.utils.file_utils import get_starting_index, parse_yaml_config
+from src.utils import get_starting_index, parse_yaml_config, setup_directories, setup_logging
+from src.utils.file_utils import save_images
 
 class TestFileUtils(unittest.TestCase):
     """
@@ -74,6 +77,102 @@ class TestFileUtils(unittest.TestCase):
             with patch('yaml.safe_load', side_effect=yaml.YAMLError("YAML error")):
                 config = parse_yaml_config("dummy_path")
                 self.assertIsNone(config)
+
+    @patch('os.makedirs')
+    def test_setup_directories(self, mock_makedirs):
+        """
+        Test the creation of directories.
+        """
+        base_dir = "test_base_dir"
+        setup_directories(base_dir)
+        expected_calls = [
+            call(os.path.join(base_dir, "left_images"), exist_ok=True),
+            call(os.path.join(base_dir, "right_images"), exist_ok=True),
+            call(os.path.join(base_dir, "depth_images"), exist_ok=True),
+            call(os.path.join(base_dir, "left_chessboard_images"), exist_ok=True),
+            call(os.path.join(base_dir, "right_chessboard_images"), exist_ok=True)
+        ]
+        mock_makedirs.assert_has_calls(expected_calls, any_order=True)
+
+    @patch('logging.basicConfig')
+    def test_setup_logging(self, mock_basic_config):
+        """
+        Test the setup of logging.
+        """
+        base_dir = "test_base_dir"
+        setup_logging(base_dir)
+        log_path = os.path.join(base_dir, "aruco_depth_log.txt")
+        mock_basic_config.assert_called_once_with(
+            filename=log_path,
+            level=logging.INFO,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+        )
+
+    @patch('cv2.imwrite')
+    @patch('os.path.join', side_effect=lambda *args: "/".join(args))
+    def test_save_images_left_right_only(self, _mock_path_join, mock_cv2_imwrite):
+        """
+        Test saving left and right images only.
+        """
+        base_dir = "./test_base_dir"
+        left_image = np.zeros((10, 10), dtype=np.uint8)
+        right_image = np.zeros((10, 10), dtype=np.uint8)
+        image_index = 1
+        prefix = "test"
+
+        save_images(base_dir, left_image, right_image, image_index,
+                    prefix=prefix)
+        mock_cv2_imwrite.assert_any_call(f"./test_base_dir/left_{prefix}_images/left_image1.png", left_image)
+        mock_cv2_imwrite.assert_any_call(f"./test_base_dir/right_{prefix}_images/right_image1.png", right_image)
+
+    @patch('cv2.imwrite')
+    @patch('numpy.save')
+    @patch('os.path.join', side_effect=lambda *args: "/".join(args))
+    def test_save_images_with_first_depth(self, _mock_path_join, mock_npy_save, mock_cv2_imwrite):
+        """
+        Test saving left, right, and first depth image.
+        """
+        base_dir = "./test_base_dir"
+        left_image = np.zeros((10, 10), dtype=np.uint8)
+        right_image = np.zeros((10, 10), dtype=np.uint8)
+        depth_image1 = np.zeros((10, 10), dtype=np.uint16)
+        image_index = 1
+        prefix = "test"
+
+        save_images(base_dir, left_image, right_image, image_index,
+                    first_depth_image=depth_image1, prefix=prefix)
+        mock_cv2_imwrite.assert_any_call(f"./test_base_dir/left_{prefix}_images/left_image1.png", left_image)
+        mock_cv2_imwrite.assert_any_call(f"./test_base_dir/right_{prefix}_images/right_image1.png", right_image)
+
+        mock_cv2_imwrite.assert_any_call("./test_base_dir/depth_images/depth_image1_1.png", depth_image1)
+        mock_npy_save.assert_any_call("./test_base_dir/depth_images/depth_image1_1.npy", depth_image1)
+
+    @patch('cv2.imwrite')
+    @patch('numpy.save')
+    @patch('os.path.join', side_effect=lambda *args: "/".join(args))
+    def test_save_images_with_first_and_second_depth(self, _mock_path_join, mock_npy_save, mock_cv2_imwrite):
+        """
+        Test saving left, right, first, and second depth images.
+        """
+        base_dir = "./test_base_dir"
+        left_image = np.zeros((10, 10), dtype=np.uint8)
+        right_image = np.zeros((10, 10), dtype=np.uint8)
+        depth_image1 = np.zeros((10, 10), dtype=np.uint16)
+        depth_image2 = np.zeros((10, 10), dtype=np.uint16)
+        image_index = 1
+        prefix = "test"
+
+        save_images(base_dir, left_image, right_image, image_index,
+                    first_depth_image=depth_image1, second_depth_image=depth_image2,
+                    prefix=prefix)
+        mock_cv2_imwrite.assert_any_call(f"./test_base_dir/left_{prefix}_images/left_image1.png", left_image)
+        mock_cv2_imwrite.assert_any_call(f"./test_base_dir/right_{prefix}_images/right_image1.png", right_image)
+
+        mock_cv2_imwrite.assert_any_call("./test_base_dir/depth_images/depth_image1_1.png", depth_image1)
+        mock_npy_save.assert_any_call("./test_base_dir/depth_images/depth_image1_1.npy", depth_image1)
+
+        mock_cv2_imwrite.assert_any_call("./test_base_dir/depth_images/depth_image2_1.png", depth_image2)
+        mock_npy_save.assert_any_call("./test_base_dir/depth_images/depth_image2_1.npy", depth_image2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -5,6 +5,7 @@ Unit tests for the file_utils module.
 import os
 import logging
 import unittest
+import coverage
 from unittest.mock import patch, mock_open, call
 
 import yaml
@@ -175,4 +176,13 @@ class TestFileUtils(unittest.TestCase):
         mock_npy_save.assert_any_call("./test_base_dir/depth_images/depth_image2_1.npy", depth_image2)
 
 if __name__ == '__main__':
+    cov = coverage.Coverage()
+    cov.start()
+
     unittest.main()
+
+    cov.stop()
+    cov.save()
+
+    cov.html_report()
+    print("Done.")

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -4,9 +4,10 @@ Unit tests for the file_utils module.
 
 import os
 import logging
+
+from unittest.mock import patch, mock_open, call
 import unittest
 import coverage
-from unittest.mock import patch, mock_open, call
 
 import yaml
 import numpy as np

--- a/tests/test_realsense_camera_system.py
+++ b/tests/test_realsense_camera_system.py
@@ -3,6 +3,7 @@ Unit tests for the RealsenseCameraSystem class.
 """
 import logging
 import unittest
+import coverage
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -149,4 +150,13 @@ class TestRealsenseCameraSystem(unittest.TestCase):
         mock_config_instance.enable_device.assert_called_once_with(serial_number)
 
 if __name__ == '__main__':
+    cov = coverage.Coverage()
+    cov.start()
+
     unittest.main()
+
+    cov.stop()
+    cov.save()
+
+    cov.html_report()
+    print("Done.")

--- a/tests/test_realsense_camera_system.py
+++ b/tests/test_realsense_camera_system.py
@@ -2,9 +2,10 @@
 Unit tests for the RealsenseCameraSystem class.
 """
 import logging
+
+from unittest.mock import MagicMock, patch
 import unittest
 import coverage
-from unittest.mock import MagicMock, patch
 
 import numpy as np
 from src.camera_objects import RealsenseCameraSystem


### PR DESCRIPTION
For realsense cameras: require disabling IR projector to properly detect chessboard corners
For FLIR cameras: Single camera calibration is possible but stereo camera calibration seems to fail
Untested for dual realsense cameras